### PR TITLE
Enabling one touch selection

### DIFF
--- a/lib/src/manager/event/pluto_grid_cell_gesture_event.dart
+++ b/lib/src/manager/event/pluto_grid_cell_gesture_event.dart
@@ -129,10 +129,17 @@ class PlutoGridCellGestureEvent extends PlutoGridEvent {
   }
 
   void _selectMode(PlutoGridStateManager stateManager) {
-    if (stateManager.isCurrentCell(cell)) {
+    if (stateManager.mode == PlutoGridMode.select && stateManager.selectingMode == PlutoGridSelectingMode.cell) {
+      if (!stateManager.isCurrentCell(cell)) {
+        stateManager.setCurrentCell(cell, rowIdx);
+      }
       stateManager.handleOnSelected();
     } else {
-      stateManager.setCurrentCell(cell, rowIdx);
+      if (stateManager.isCurrentCell(cell)) {
+        stateManager.handleOnSelected();
+      } else {
+        stateManager.setCurrentCell(cell, rowIdx);
+      }
     }
   }
 


### PR DESCRIPTION
Enabling one touch selection when:
mode = PlutoGridMode.select
stateManager.selectingMode = PlutoGridSelectingMode.cell