### PR TITLE
Updated Pluto Grid cells to use GlobalKeys

### DIFF
--- a/lib/src/model/pluto_cell.dart
+++ b/lib/src/model/pluto_cell.dart
@@ -5,7 +5,7 @@ import 'pluto_column.dart';
 class PlutoCell {
   PlutoCell({
     dynamic value,
-  })  : _key = UniqueKey(),
+  })  : _key = GlobalKey(),
         _value = value;
 
   /// cell key


### PR DESCRIPTION
Updated Pluto Grid cells to use GlobalKeys so app can get RenderBoxes for the cells.

This is convenient for creating context menus and in general being aware where the cell is being displayed on the screen.